### PR TITLE
Use `ugettext_lazy` instead of `ugettext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Enter here all the changes made to the development version
 
+### Fixed
+
+- Use `ugettext_lazy` instead of `ugettext`
+
 ## [1.0.8] - 2021-02-23
 
 - Allow updating stock to zero

--- a/shuup_product_variations/sections.py
+++ b/shuup_product_variations/sections.py
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 from django.conf import settings
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 from shuup.admin.base import Section
 from shuup.admin.shop_provider import get_shop
 from shuup.admin.supplier_provider import get_supplier


### PR DESCRIPTION
`gettext` causes issues with translated strings not updating when language is changed